### PR TITLE
Remove tooling webserver from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0.100-alpine3.12-amd64 AS build
 WORKDIR /app
 
-# Download exercism tooling webserver
-RUN wget -P /usr/local/bin https://github.com/exercism/tooling-webserver/releases/download/0.10.0/tooling_webserver && \
-    chmod +x /usr/local/bin/tooling_webserver
-
 # Copy fsproj and restore as distinct layers
 COPY src/Exercism.TestRunner.FSharp/Exercism.TestRunner.FSharp.fsproj ./
 RUN dotnet restore -r linux-musl-x64


### PR DESCRIPTION
The tooling webserver has been obsoleted due to https://github.com/exercism/tooling-invoker/pull/29